### PR TITLE
fix: allow broker client to serve tls [HYB-737]

### DIFF
--- a/snyk-universal-broker/templates/_helpers.tpl
+++ b/snyk-universal-broker/templates/_helpers.tpl
@@ -64,6 +64,13 @@ include "snyk-broker.genericSecretName" (dict "Context" $ "secretName" "secret-n
 {{- end -}}
 
 {{/*
+Create a name for the TLS secret, using a provided override if present
+*/}}
+{{- define "snyk-broker.tlsSecretName" -}}
+{{- .Values.localWebServerSecret.name | default ( include "snyk-broker.genericSecretName" (dict "Context" . "secretName" "tls-secret" ) ) -}}
+{{- end }}
+
+{{/*
 Create a name for the CA Cert secret, using a provided override if present
 */}}
 {{- define "snyk-broker.caCertSecretName" -}}

--- a/snyk-universal-broker/templates/statefulset.yaml
+++ b/snyk-universal-broker/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
             httpGet:
               port: {{ .Values.containerPort }}
               path: {{ .Values.livenessProbe.path }}
-              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.enableBrokerLocalWebserverOverHttps ) ( .Values.ingress.enabled )}}
+              {{- if or ( and (.Values.localWebServer.certificate) (.Values.localWebServer.key) ) ( .Values.localWebServer.https ) }}
               scheme: HTTPS
               {{- else }}
               scheme: HTTP
@@ -77,7 +77,7 @@ spec:
             httpGet:
               port: {{ .Values.containerPort }}
               path: {{ .Values.readinessProbe.path }}
-              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.enableBrokerLocalWebserverOverHttps ) (.Values.ingress.enabled) }}
+              {{- if or ( and (.Values.localWebServer.certificate) (.Values.localWebServer.key) ) ( .Values.localWebServer.https ) }}
               scheme: HTTPS
               {{- else }}
               scheme: HTTP
@@ -104,8 +104,8 @@ spec:
                 mountPath: {{ printf "%s/%s" .Values.caCertMount.path .Values.caCertMount.name }}
                 readOnly: true
               {{- end }}
-              {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
-              - name: {{ include "common.names.fullname" .}}-tls-secret-volume
+              {{- if or .Values.localWebServerSecret.name ( and (.Values.localWebServer.certificate) (.Values.localWebServer.key) ) }}
+              - name: {{ .Release.Name }}-tls-secret-volume
                 mountPath: /home/node/tls-cert/
                 readOnly: true
               {{- end }}
@@ -135,15 +135,17 @@ spec:
             - name: NODE_EXTRA_CA_CERTS
               value: {{ printf "%s/%s" .Values.caCertMount.path .Values.caCertMount.name }}
           {{- end }}
-         {{- if .Values.httpsCert }}
-         # HTTPS Config
+          {{- if .Values.localWebServer.https }}
+          {{- if or .Values.localWebServerSecret.name .Values.localWebServer.certificate }}
+          # HTTPS Config
             - name: HTTPS_CERT
               value: /home/node/tls-cert/tls.crt
-         {{- end }}
-         {{- if .Values.httpsKey }}
+          {{- end }}
+          {{- if or .Values.localWebServerSecret.name .Values.localWebServer.key }}
             - name: HTTPS_KEY
               value: /home/node/tls-cert/tls.key
-         {{- end }}
+          {{- end }}
+          {{- end }}
         {{- if or (and .Values.tlsRejectUnauthorized (not .Values.caCert)) (and .Values.caCert .Values.disableAllCertificateTrust) }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
@@ -189,8 +191,8 @@ spec:
             path: {{ .Values.caCertMount.name }}
       {{- end }}
       {{- end }}
-      {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
-      - name: {{ include "common.names.fullname" . }}-tls-secret-volume
+      {{- if or .Values.localWebServerSecret.name ( and (.Values.localWebServer.certificate) (.Values.localWebServer.key) ) }}
+      - name: {{ .Release.Name }}-tls-secret-volume
         secret:
           secretName: {{ include "snyk-broker.tlsSecretName" . }}
       {{- end }}

--- a/snyk-universal-broker/templates/tls-secret.yaml
+++ b/snyk-universal-broker/templates/tls-secret.yaml
@@ -1,28 +1,17 @@
 ---
-{{- if and (.Values.httpsCert) (.Values.httpsKey) }}
+{{- if and (.Values.localWebServer.certificate) (.Values.localWebServer.key) (not .Values.localWebServerSecret.name ) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-certs
+  name: {{ include "snyk-broker.tlsSecretName" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.httpsCert | b64enc | nindent 4 }}
-  tls.key: {{ .Values.httpsKey | b64enc | nindent 4 }}
+  tls.crt: {{ .Values.localWebServer.certificate | b64enc | nindent 4 }}
+  tls.key: {{ .Values.localWebServer.key | b64enc | nindent 4 }}
 ---
 {{- end }}
-{{- if .Values.caCert }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "common.names.fullname" . }}-cacerts
-  namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-data:
-  cacert: {{ .Values.caCert | b64enc | nindent 4}}
-{{- end }}
----
 {{- if .Values.ingress.enabled }}
 {{- if and .Values.ingress.tls.enabled (not .Values.ingress.existingSecret) }}
 apiVersion: v1

--- a/snyk-universal-broker/tests/https_webserver_test.yaml
+++ b/snyk-universal-broker/tests/https_webserver_test.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Ingress
+templates:
+  - ingress.yaml
+  - statefulset.yaml
+  - tls-secret.yaml
+values:
+  - ../values.yaml
+  - fixtures/default_values.yaml
+
+tests:
+  - it: Serves broker via https with a provided certificate and key
+    set:
+      localWebServer.https: true
+      localWebServer.certificate: "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"
+      localWebServer.key: "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: "HTTPS"
+        template: statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: "HTTPS"
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-tls-secret-volume
+            secret:
+              secretName: RELEASE-NAME-tls-secret
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_CERT
+            value: /home/node/tls-cert/tls.crt
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_KEY
+            value: /home/node/tls-cert/tls.key
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-tls-secret-volume
+            mountPath: /home/node/tls-cert/
+            readOnly: true
+        template: statefulset.yaml
+      - hasDocuments:
+          count: 1
+        template: tls-secret.yaml
+      - containsDocument:
+          kind: Secret
+          name: RELEASE-NAME-tls-secret
+          apiVersion: v1
+          namespace: NAMESPACE
+        template: tls-secret.yaml
+
+  - it: Serves broker via https with an external secret
+    set:
+      localWebServer.https: true
+      localWebServerSecret.name: my-tls-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: "HTTPS"
+        template: statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: "HTTPS"
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_CERT
+            value: /home/node/tls-cert/tls.crt
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_KEY
+            value: /home/node/tls-cert/tls.key
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-tls-secret-volume
+            secret:
+              secretName: my-tls-secret
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-tls-secret-volume
+            mountPath: /home/node/tls-cert/
+            readOnly: true
+        template: statefulset.yaml
+      - hasDocuments:
+          count: 0
+        template: tls-secret.yaml

--- a/snyk-universal-broker/tests/ingress_test.yaml
+++ b/snyk-universal-broker/tests/ingress_test.yaml
@@ -43,7 +43,7 @@ tests:
           path: apiVersion
           value: "networking.k8s.io/v1beta1"
     template: ingress.yaml
-  
+
   - it: Modifies the api version accordingly (pre 1.21)
     capabilities:
       majorVersion: 1
@@ -154,7 +154,7 @@ tests:
   - it: Defaults to first secret if no annotation or existing secret is specified
     set:
       ingress.tls.enabled: true
-      ingress.secrets: 
+      ingress.secrets:
         - name: "my-new-secret"
           certificate: "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"
           key: "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----"
@@ -165,7 +165,7 @@ tests:
         template: ingress.yaml
       - isKind:
           of: Secret
-        template: ingress-secret.yaml     
+        template: ingress-secret.yaml
       - hasDocuments:
          count: 1
         template: ingress-secret.yaml
@@ -177,7 +177,7 @@ tests:
   - it: Creates many secrets across many hosts
     set:
       ingress.tls.enabled: true
-      ingress.secrets: 
+      ingress.secrets:
         - name: "my-new-secret"
           certificate: "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"
           key: "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----"

--- a/snyk-universal-broker/values.schema.json
+++ b/snyk-universal-broker/values.schema.json
@@ -331,6 +331,31 @@
         }
       }
     },
+    "localWebServer": {
+      "type": "object",
+      "properties": {
+        "https": {
+          "type": "boolean",
+          "default": false
+        },
+        "certificate": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "localWebServerSecret": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "global": {
       "type": "object",
       "additionalProperties": true

--- a/snyk-universal-broker/values.yaml
+++ b/snyk-universal-broker/values.yaml
@@ -216,14 +216,17 @@ readinessProbe:
 logLevel: "info"
 logEnableBody: "false"
 
-## Enable HTTPS #####
-## @param enableBrokerLocalWebserverOverHttps enables Broker client to run a HTTPS server instead of the default HTTP server
-## @param httpsCert provides HTTPS cert
-## @param httpsKey provides HTTPS cert key
-
-enableBrokerLocalWebserverOverHttps: false
-httpsCert: ""
-httpsKey: ""
+## @section Serving over HTTPS and Certificate Trust
+## @param localWebServer.https [default: false] enables Broker client to run a HTTPS server instead of the default HTTP server
+## @param localWebServer.certificate [string] Provide HTTPS cert
+## @param localWebServer.key [string] Provides HTTPS cert key
+localWebServer:
+  https: false
+  certificate: ""
+  key: ""
+## @param localWebServerSecret.name the name of the secret to create or (if cert and key are empty) the existing TLS secret to use
+localWebServerSecret:
+  name: ""
 
 ##### HTTPS Inspection #####
 


### PR DESCRIPTION
### What

- Enables Broker to serve a TLS endpoint with provided certificate/key
- Removes incorrect test
