### PR TITLE
fix: security context, openshift adaptation [HYB-728]

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,28 +288,28 @@ helm install ... --set credentialReferences.MY_GITHUB_TOKEN=<gh-pat>
 
 ### Service Account
 
-| Name                                                | Description                                                                                  | Value            |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
-| `serviceAccount.create`                             | Enable creation of a serviceAccount                                                          | `true`           |
-| `serviceAccount.existingName`                       | Optionally provide an existing serviceAccount name                                           | `""`             |
-| `serviceAccount.annotations`                        | Additional custom annotations for the serviceAccount                                         | `{}`             |
-| `serviceAccount.name`                               | The name of the serviceAccount to create. If not set and create is true, a name is generated | `""`             |
-| `podSecurityContext.enabled`                        | Enable security context for Broker Pods                                                      | `true`           |
-| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                           | `Always`         |
-| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                               | `[]`             |
-| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                  | `[]`             |
-| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod                                                          | `1000`           |
-| `containerSecurityContext.enabled`                  | Enabled Broker containers' Security Context                                                  | `true`           |
-| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                             | `{}`             |
-| `containerSecurityContext.runAsUser`                | Set Broker  containers' Security Context runAsUser                                           | `1000`           |
-| `containerSecurityContext.runAsGroup`               | Set Broker containers' Security Context runAsGroup                                           | `1000`           |
-| `containerSecurityContext.allowPrivilegeEscalation` | Set Broker containers' Security Context allowPrivilegeEscalation                             | `false`          |
-| `containerSecurityContext.capabilities.drop`        | Set containers' repo server Security Context capabilities to be dropped                      | `["ALL"]`        |
-| `containerSecurityContext.readOnlyRootFilesystem`   | Set containers' repo server Security Context readOnlyRootFilesystem                          | `true`           |
-| `containerSecurityContext.runAsNonRoot`             | Set Broker containers' Security Context runAsNonRoot                                         | `true`           |
-| `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                  | `false`          |
-| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                             | `RuntimeDefault` |
-| `extraVolumes`                                      | Optionally specify extra list of additional volumes for Broker container                     | `[]`             |
-| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for Broker container                | `[]`             |
-| `extraEnvVars`                                      | Optionally specify extra list of additional environment variables for Broker container       | `[]`             |
+| Name                                                | Description                                                                                  | Value              |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------ |
+| `serviceAccount.create`                             | Enable creation of a serviceAccount                                                          | `true`             |
+| `serviceAccount.existingName`                       | Optionally provide an existing serviceAccount name                                           | `""`               |
+| `serviceAccount.annotations`                        | Additional custom annotations for the serviceAccount                                         | `{}`               |
+| `serviceAccount.name`                               | The name of the serviceAccount to create. If not set and create is true, a name is generated | `""`               |
+| `podSecurityContext.enabled`                        | Enable security context for Broker Pods                                                      | `true`             |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                           | `Always`           |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                               | `[]`               |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                  | `[]`               |
+| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod                                                          | `1000`             |
+| `containerSecurityContext.enabled`                  | Enable Broker container security context                                                     | `true`             |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options for Broker container                                                     | `{}`               |
+| `containerSecurityContext.runAsUser`                |                                                                                              | `1000`             |
+| `containerSecurityContext.runAsGroup`               |                                                                                              | `1000`             |
+| `containerSecurityContext.allowPrivilegeEscalation` | Allow the Broker container to escalate privileges                                            | `false`            |
+| `containerSecurityContext.capabilities.drop`        | ] Linux capabilities to drop                                                                 | `""`               |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Must be set to false; Broker will write configuration to filesystem upon startup             | `false`            |
+| `containerSecurityContext.runAsNonRoot`             | Run Broker as non-root                                                                       | `true`             |
+| `containerSecurityContext.privileged`               | Run Broker as a privileged container                                                         | `false`            |
+| `containerSecurityContext.seccompProfile.type`      | Set the `seccomProfile` for Broker                                                           | `"RunTimeDefault"` |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for Broker container                     | `[]`               |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for Broker container                | `[]`               |
+| `extraEnvVars`                                      | Optionally specify extra list of additional environment variables for Broker container       | `[]`               |
 

--- a/snyk-universal-broker/tests/compatibility_test.yaml
+++ b/snyk-universal-broker/tests/compatibility_test.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: OpenShift Compatibility
+templates:
+  - statefulset.yaml
+values:
+  - ../values.yaml
+  - fixtures/default_values.yaml
+
+tests:
+  - it: Adjusts the security context for OpenShift
+    capabilities:
+      apiVersions:
+        - "security.openshift.io/v1"
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.seLinuxOptions
+
+  - it: Keeps the security context if not OpenShift
+    asserts:
+      - exists:
+          path: spec.template.spec.securityContext.fsGroup
+      - exists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - exists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+      - exists:
+          path: spec.template.spec.containers[0].securityContext.seLinuxOptions
+
+  - it: Allows for mounting of OpenShift CA via ConfigMap
+    ## ref: https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki
+    set:
+      extraVolumes:
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
+      extraVolumeMounts:
+        - name: trusted-ca
+          mountPath: /home/node/cacert
+          readOnly: true
+      caCertMount:
+        path: /home/node/cacert
+        name: tls-ca-bundle.pem
+      extraEnvVars:
+        - name: CA_CERT
+          value: /home/node/cacert/tls-ca-bundle.pem
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: trusted-ca
+            mountPath: /home/node/cacert
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: tls-ca-bundle.pem
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CA_CERT
+            value: /home/node/cacert/tls-ca-bundle.pem

--- a/snyk-universal-broker/tests/pod_runtimes_test.yaml
+++ b/snyk-universal-broker/tests/pod_runtimes_test.yaml
@@ -7,50 +7,27 @@ templates:
   - statefulset.yaml
 
 tests:
-  - it: should set pod security context when enabled
-    set:
-      podSecurityContext.enabled: true
-      podSecurityContext.fsGroup: 1001
-      podSecurityContext.fsGroupChangePolicy: "Always"
-      podSecurityContext.supplementalGroups: [2000]
-      podSecurityContext.sysctls:
-        - name: "net.core.somaxconn"
-          value: "1024"
+  - it: should set pod security context by default
     asserts:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
-          value: 1001
-      - equal:
-          path: spec.template.spec.securityContext.fsGroupChangePolicy
-          value: "Always"
-      - equal:
-          path: spec.template.spec.securityContext.supplementalGroups[0]
-          value: 2000
-      - equal:
-          path: spec.template.spec.securityContext.sysctls[0].name
-          value: "net.core.somaxconn"
-      - equal:
-          path: spec.template.spec.securityContext.sysctls[0].value
-          value: "1024"
+          value: 1000
 
-  - it: should set container security context when enabled
+  - it: disables pod security context
     set:
-      containerSecurityContext.enabled: true
-      containerSecurityContext.runAsUser: 1001
-      containerSecurityContext.runAsGroup: 1001
-      containerSecurityContext.runAsNonRoot: true
-      containerSecurityContext.allowPrivilegeEscalation: false
-      containerSecurityContext.capabilities.drop: ["ALL"]
-      containerSecurityContext.seccompProfile.type: "RuntimeDefault"
-      containerSecurityContext.privileged: false
-      containerSecurityContext.readOnlyRootFilesystem: true
+      podSecurityContext.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: should set container security context by default
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
-          value: 1001
+          value: 1000
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
-          value: 1001
+          value: 1000
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
@@ -68,7 +45,60 @@ tests:
           value: false
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
-          value: true
+          value: false
+
+  - it: disables container security context
+    set:
+      containerSecurityContext.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: sets extra pod security context options
+    set:
+      podSecurityContext.fsGroup: 1001
+      podSecurityContext.fsGroupChangePolicy: "OnRootMismatch"
+      podSecurityContext.supplementalGroups: [2000]
+      podSecurityContext.sysctls:
+        - name: "net.core.somaxconn"
+          value: "1024"
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: "OnRootMismatch"
+      - contains:
+          path: spec.template.spec.securityContext.supplementalGroups
+          content:
+            2000
+      - contains:
+          path: spec.template.spec.securityContext.sysctls
+          content:
+            name: "net.core.somaxconn"
+            value: "1024"
+
+  - it: sets extra container security context options
+    set:
+      containerSecurityContext.seLinuxOptions:
+        level: "s0:c123,c456"
+      containerSecurityContext.capabilities.add:
+        - "NET_ADMIN"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.seLinuxOptions.level
+          value: "s0:c123,c456"
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content:
+            "NET_ADMIN"
+
+  - it: fails if readOnlyRootFilesystem is `true`
+    set:
+      containerSecurityContext.readOnlyRootFilesystem: true
+    asserts:
+      - failedTemplate: {}
 
   - it: can add tolerations
     set:

--- a/snyk-universal-broker/values.schema.json
+++ b/snyk-universal-broker/values.schema.json
@@ -203,7 +203,101 @@
         }
       }
     },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "fsGroupChangePolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "OnRootMismatch"
+          ]
+        },
+        "sysctls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "supplementalGroups": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "fsGroup": {
+          "type": "integer",
+          "default": 1000
+        }
+      }
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "seLinuxOptions": {
+          "type": "object"
+        },
+        "runAsUser": {
+          "type": "integer",
+          "default": 1000
+        },
+        "runAsGroup": {
+          "type": "integer",
+          "default": 1000
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "default": true
+        },
+        "privileged": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "default": false
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "seccompProfile": {
+          "type": "object"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "enum": [
+            false
+          ],
+          "default": false
+        }
+      }
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "additionalProperties": false
-  },
-  "additionalProperties": true
+  }
 }

--- a/snyk-universal-broker/values.yaml
+++ b/snyk-universal-broker/values.yaml
@@ -294,17 +294,17 @@ podSecurityContext:
 
 ## Container security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-## @param containerSecurityContext.enabled Enabled Broker containers' Security Context
-## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
-## @param containerSecurityContext.runAsUser Set Broker  containers' Security Context runAsUser
-## @param containerSecurityContext.runAsGroup Set Broker containers' Security Context runAsGroup
-## @param containerSecurityContext.allowPrivilegeEscalation Set Broker containers' Security Context allowPrivilegeEscalation
-## @param containerSecurityContext.capabilities.drop Set containers' repo server Security Context capabilities to be dropped
-## @param containerSecurityContext.readOnlyRootFilesystem Set containers' repo server Security Context readOnlyRootFilesystem
-## @param containerSecurityContext.runAsNonRoot Set Broker containers' Security Context runAsNonRoot
-## @param containerSecurityContext.privileged Set container's Security Context privileged
-## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
-##
+## @param containerSecurityContext.enabled [default:true] Enable Broker container security context
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options for Broker container
+## @param containerSecurityContext.runAsUser [default: 1000]
+## @param containerSecurityContext.runAsGroup [default: 1000]
+## @param containerSecurityContext.allowPrivilegeEscalation [default:false] Allow the Broker container to escalate privileges
+## @param containerSecurityContext.capabilities.drop [default: ["ALL"]] Linux capabilities to drop
+## @param containerSecurityContext.readOnlyRootFilesystem [default:false] Must be set to false; Broker will write configuration to filesystem upon startup
+## @param containerSecurityContext.runAsNonRoot [default:true] Run Broker as non-root
+## @param containerSecurityContext.privileged [default: false] Run Broker as a privileged container
+## @param containerSecurityContext.seccompProfile.type [default:"RunTimeDefault"] Set the `seccomProfile` for Broker
+
 containerSecurityContext:
   enabled: true
   seLinuxOptions: {}
@@ -317,7 +317,7 @@ containerSecurityContext:
     drop: ["ALL"]
   seccompProfile:
     type: "RuntimeDefault"
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
 
 ## @param extraVolumes Optionally specify extra list of additional volumes for Broker container
 extraVolumes: []
@@ -327,3 +327,9 @@ extraVolumeMounts: []
 
 ## @param extraEnvVars Optionally specify extra list of additional environment variables for Broker container
 extraEnvVars: []
+
+## @skip global.compatibility.openshift.adaptSecurityContext [default: auto] Set to false to disable security context adaptations for OpenShift. If left in "auto", will remove default user/group values that will violate an OpenShift Security Context
+global:
+  compatibility:
+    openshift:
+      adaptSecurityContext: auto


### PR DESCRIPTION
### What

- Sets the security contexts for Broker correctly, ensuring `readOnlyRootFilesystem` is always `false`
- Ensures the OpenShift adapation for security context functions

### Why

- Broker writes to `config.universal.json` on start-up, therefore requiring a r/w root file system
