### PR TITLE
fix: extra k8s objects, sidecars, initContainers [HYB-741]

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,22 @@ THen set values within `localWebServerSecret` to reference this external Secret:
 localWebServerSecret:
   name: broker-tls
 ```
+### Extending the Helm Chart
+
+#### Arbitrary Kubernetes Objects
+
+Use the [Additional Objects](#additional-objects) values to add ConfigMaps, Secrets, Sidecars, initContainers, Volumes and VolumeMounts to the Universal Broker.
+
+#### Additional Environment Variables
+
+Use `extraEnvVars` to add arbitrary environment variables directly in Helm:
+
+```yaml
+extraEnvVars:
+  - MY_ENV_VAR: myvalue
+```
+
+_Note:_ Check for duplicate environment variables.
 
 ## Parameters
 

--- a/snyk-universal-broker/templates/statefulset.yaml
+++ b/snyk-universal-broker/templates/statefulset.yaml
@@ -49,6 +49,10 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: universal-broker
           resources: {{- toYaml .Values.resources | nindent 12 }}
@@ -98,6 +102,14 @@ spec:
             - secretRef:
                 name: {{ include "snyk-broker.commitSigningSecretName" . }}
           {{- end }}
+            {{- range .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) }}
+            {{- end }}
+            {{- range .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) }}
+            {{- end }}
           volumeMounts:
               {{- if or .Values.caCert .Values.caCertSecret.name }}
               - name: {{ .Release.Name }}-cacert-volume
@@ -109,9 +121,9 @@ spec:
                 mountPath: /home/node/tls-cert/
                 readOnly: true
               {{- end }}
-{{- if .Values.extraVolumeMounts }}
-{{ tpl (toYaml .Values.extraVolumeMounts | indent 14) . }}
-{{- end }}
+              {{- if .Values.extraVolumeMounts }}
+              {{- tpl (toYaml .Values.extraVolumeMounts | nindent 14 ) . }}
+              {{- end }}
           env:
             - name: BROKER_SERVER_URL
               value: {{ include "snyk-broker.brokerServerUrl" . }}
@@ -160,6 +172,9 @@ spec:
         {{- range .Values.extraEnvVars }}
             - name: {{ .name }}
               value: {{ .value | squote }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       # Mount Accept.json and Certs
       volumes:

--- a/snyk-universal-broker/tests/extras_test.yaml
+++ b/snyk-universal-broker/tests/extras_test.yaml
@@ -1,0 +1,97 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Extras
+templates:
+  - statefulset.yaml
+values:
+- ../values.yaml
+- fixtures/default_values.yaml
+
+tests:
+  - it: creates extra volumes
+    set: 
+      extraVolumes:
+        - name: my-empty-dir
+          emptyDir:
+            sizeLimit: 500Mi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: my-empty-dir
+            emptyDir:
+              sizeLimit: 500Mi
+
+  - it: mounts extra volumes
+    set: 
+      extraVolumes:
+        - name: my-empty-dir
+          emptyDir:
+            sizeLimit: 500Mi
+      extraVolumeMounts:
+        - name: my-empty-dir
+          mountPath: "/scratch"
+          readOnly: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: my-empty-dir
+            emptyDir:
+              sizeLimit: 500Mi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: my-empty-dir
+            mountPath: "/scratch"
+            readOnly: false
+
+  - it: Sets extra env vars
+    set:
+      extraEnvVars:
+        - name: MY_VAR
+          value: "myvalue"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_VAR
+            value: "myvalue"
+
+  - it: Sets extra env vars from a configmap
+    set:
+      extraEnvVarsCM:
+        - "my-external-configmap"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: "my-external-configmap"
+
+  - it: Sets extra env vars from a secret
+    set:
+      extraEnvVarsSecret:
+        - "my-external-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: "my-external-secret"
+
+  - it: Sets extra env vars from multiple secrets
+    set:
+      extraEnvVarsSecret:
+        - "my-external-secret"
+        - "my-special-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: "my-external-secret"
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: "my-special-secret"

--- a/snyk-universal-broker/tests/initcontainers_sidecars_test.yaml
+++ b/snyk-universal-broker/tests/initcontainers_sidecars_test.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: InitContainers, Sidecars
+templates:
+  - statefulset.yaml
+values:
+  - ../values.yaml
+  - fixtures/default_values.yaml
+
+tests:
+  - it: Adds an initContainer
+    set:
+      initContainers:
+      - name: your-image-name
+        image: your-image
+        imagePullPolicy: Always
+        command: ['sh', '-c', 'echo "hello world"']
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: your-image-name
+            image: your-image
+            imagePullPolicy: Always
+            command: ['sh', '-c', 'echo "hello world"']
+
+  - it: Adds a sidecar
+    set:
+      sidecars:
+        - name: your-image-name
+          image: your-image
+          imagePullPolicy: Always
+          ports:
+            - name: portname
+              containerPort: 1234
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2


### PR DESCRIPTION
### What

- Allow arbitrary initContainers, sidecars
- Enable extra volumes, volumeMounts, configMaps, Secrets to be defined
