### PR TITLE
fix: sign helm chart [HYB-731]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
       - run:
           name: Run semantic-release
           command: npx semantic-release
+## Note - signing happens via GitHub Action to leverage OIDC. CircleCI doesn't support this directly, yet.
 
   security_scans:
     docker:

--- a/.github/workflows/sigstore.yml
+++ b/.github/workflows/sigstore.yml
@@ -1,0 +1,33 @@
+on:
+  ## This workflow only runs on the default branch
+  check_suite:
+    types: [completed]
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    name: Sign Chart
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+      - name: Check Cosign
+        run: cosign version
+      - name: Cosign with OIDC
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags 'git rev-list --tags --max-count=1')
+          # Obtain the digest from this tag
+          DIGEST=$(curl "https://hub.docker.com/v2/repositories/snyk/snyk-universal-broker/tags/${LATEST_TAG}" | jq '.digest' -r)
+          # Sign the image, using GitHub as an OIDC provider
+          cosign sign --yes oci://registry-1.docker.io/snyk/snyk-universal-broker-helm@${DIGEST}
+      - name: Verify signature
+        run: |
+          cosign verify oci://registry-1.docker.io/snyk/snyk-universal-broker-helm@${DIGEST}
+          cosign verify oci://registry-1.docker.io/snyk/snyk-universal-broker-helm@${LATEST_TAG}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This is a Helm Chart to deploy the [Snyk Universal Broker](https://docs.snyk.io/
 
 ## Requirements
 
+- Helm `3.8.0` or newer
+- (Optionally) the `helm-sigstore` Helm plugin, or `cosign`
+
 ### Networking
 
 #### Outbound
@@ -20,6 +23,14 @@ If a proxy, firewall, or other network appliance sits between Broker and the pub
 
 - the above domains are whitelisted, _and_
 - the proxy, firewall or other network appliance supports the websockets protocol
+
+## Installing the Helm Chart for Universal Broker
+
+Pull the Helm Chart, and provide any configuration necessary:
+
+```
+helm pull oci://registry-1.docker.io/snyk/snyk-universal-broker
+```
 
 ## Basic Configuration
 


### PR DESCRIPTION
### What

- Sign the Helm Chart with `cosign`, leveraging keyless signature via OIDC

### Why

- Maintaining a key requires additional operational considerations

### More

Keyless signatures are beneficial as:
- No private key material must be maintained or rotated
- No public key material must be made avaialble to end users

#### How

The GitHub Actions OIDC token is supported by `cosign` as an OIDC provider - no additional configuration is required aside from specifying the `id-token: write` permission. This is why we need to sign OCI artefacts in a GitHub Actions workflow.

The CircleCI OIDC token does not support the required fields to be leveraged by `cosign` as a native OIDC provider (https://github.com/sigstore/fulcio/issues/591).

#### Refs

- https://www.chainguard.dev/unchained/zero-friction-keyless-signing-with-github-actions
