### PR TITLE
fix: strip v from tag [HYB-731]

### DIFF
--- a/.github/workflows/sigstore.yml
+++ b/.github/workflows/sigstore.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cosign with OIDC
         run: |
           # Get the latest tag
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1` | tr -d 'v')
           # Obtain the digest from this tag
           DIGEST=$(curl "https://hub.docker.com/v2/repositories/snyk/snyk-universal-broker/tags/${LATEST_TAG}" | jq '.digest' -r)
           # Sign the image, using GitHub as an OIDC provider


### PR DESCRIPTION
### What

- Strip the leading `v` from the tag returned from `git`

### Why

- We want to query for the digest by `x.y.z-rc00`, not `vx.y.z-rc00`
