### PR TITLE
Fix/ingress tls secret

### DIFF
--- a/snyk-universal-broker/Chart.yaml
+++ b/snyk-universal-broker/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - bitnami-common
-  version: 2.x.x
+  version: 2.30.0
 description: A Helm chart for Kubernetes
 name: snyk-universal-broker
 type: application

--- a/snyk-universal-broker/templates/ingress-secret.yaml
+++ b/snyk-universal-broker/templates/ingress-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-{{- if and .Values.ingress.tls.enabled .Values.ingress.secrets }}
+{{- if and .Values.ingress.tls.enabled .Values.ingress.secrets (not .Values.ingress.tls.existingSecret) }}
 {{- range .Values.ingress.secrets }}
 {{- if and .certificate .key }}
 apiVersion: v1

--- a/snyk-universal-broker/templates/tls-secret.yaml
+++ b/snyk-universal-broker/templates/tls-secret.yaml
@@ -12,21 +12,3 @@ data:
   tls.key: {{ .Values.localWebServer.key | b64enc | nindent 4 }}
 ---
 {{- end }}
-{{- if .Values.ingress.enabled }}
-{{- if and .Values.ingress.tls.enabled (not .Values.ingress.existingSecret) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $.Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ .Values.ingress.tls.secret.cert | b64enc | b64enc }}
-  tls.key: {{ .Values.ingress.tls.secret.key | b64enc | b64enc }}
----
-{{- end }}
-{{- end }}

--- a/snyk-universal-broker/tests/ingress_test.yaml
+++ b/snyk-universal-broker/tests/ingress_test.yaml
@@ -141,6 +141,19 @@ tests:
           value: broker.corp.tld-tls
     template: ingress.yaml
 
+  - it: Does not create a new ingress TLS secret if existingSecret is provided
+    set:
+      ingress.tls.enabled: true
+      ingress.tls.existingSecret: "my-test-existing-secret"
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: ingress-secret.yaml
+      - equal:
+          path: spec.tls[0].secretName
+          value: "my-test-existing-secret"
+        template: ingress.yaml
+
   - it: Respects existing secret
     set:
       ingress.tls.enabled: true


### PR DESCRIPTION
What:
- Refactors ingress tls secret creation
- Fixes bug `.Values.ingress.tls.existingSecret`
- Unit test
- Need to lock down bitnami common chart version to support customers who might be using older k8s version