### PR TITLE
fix: change pullPolicy to Always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
       - helm/install_helm_client
       - helm/install_helm_plugin:
           helm_plugin_url: https://github.com/helm-unittest/helm-unittest
+          plugin_version: v1.0.3
       - run:
           name: Install Pre-reqs
           command: |

--- a/README.md
+++ b/README.md
@@ -522,13 +522,13 @@ helm install ... --set credentialReferences.MY_GITHUB_TOKEN=<gh-pat>
 
 ### Image Registry
 
-| Name                | Description                                        | Value          |
-| ------------------- | -------------------------------------------------- | -------------- |
-| `image.registry`    | Broker image registry                              | `docker.io`    |
-| `image.repository`  | Broker image repository                            | `snyk/broker`  |
-| `image.tag`         | Broker image tag                                   | `universal`    |
-| `image.pullPolicy`  | Broker image pull policy                           | `IfNotPresent` |
-| `image.pullSecrets` | Optionally provide any existing image pull secrets | `[]`           |
+| Name                | Description                                        | Value         |
+| ------------------- | -------------------------------------------------- | ------------- |
+| `image.registry`    | Broker image registry                              | `docker.io`   |
+| `image.repository`  | Broker image repository                            | `snyk/broker` |
+| `image.tag`         | Broker image tag                                   | `universal`   |
+| `image.pullPolicy`  | Broker image pull policy                           | `Always`      |
+| `image.pullSecrets` | Optionally provide any existing image pull secrets | `[]`          |
 
 ### Service Account
 

--- a/snyk-universal-broker/values.yaml
+++ b/snyk-universal-broker/values.yaml
@@ -312,12 +312,12 @@ readinessProbe:
 ## @param image.registry [default: docker.io] Broker image registry
 ## @param image.repository [default: snyk/broker] Broker image repository
 ## @param image.tag [default: universal] Broker image tag
-## @param image.pullPolicy [default: IfNotPresent] Broker image pull policy
+## @param image.pullPolicy [default: Always] Broker image pull policy
 ## @param image.pullSecrets [array] Optionally provide any existing image pull secrets
 image:
   registry: docker.io
   repository: snyk/broker
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag
   tag: "universal"
   pullSecrets: []


### PR DESCRIPTION
This PR changes `image.pullPolicy` to `Always`. This will ensure regular updates of images.

https://docs.snyk.io/implementation-and-setup/enterprise-setup/snyk-broker/update-the-snyk-broker-client#updating-using-the-helm-method