### PR TITLE
feat: allow to specify workload type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y kubectl
       - run:
-          name: Deploy Universal Broker
+          name: Deploy Universal Broker (StatefulSet)
           command: |
             helm dep up
             k3d cluster create
@@ -131,7 +131,36 @@ jobs:
               .
           working_directory: snyk-universal-broker
       - run:
-          name: Test Import
+          name: Test Import (StatefulSet)
+          command: |
+            LOG_LEVEL="debug" \
+              SNYK_TOKEN=${<<parameters.snyk-token>>} \
+              npx \
+              --yes \
+              tsx \
+              .circleci/scripts/testImport/testImport.ts \
+              ".circleci/snyk-import/snyk-import-gh.json" \
+              "https://api.dev.snyk.io"
+      - run:
+          name: Deploy Universal Broker (Deployment)
+          command: |
+            k3d cluster delete
+            k3d cluster create
+            helm install \
+              --debug \
+              --wait \
+              -f values.yaml \
+              --set region=dev \
+              --set workload.kind=deployment \
+              --set deploymentId=${<<parameters.deployment-id>>} \
+              --set clientId=${<<parameters.client-id>>} \
+              --set clientSecret=${<<parameters.client-secret>>} \
+              --set credentialReferences.MY_GITHUB_TOKEN=${<<parameters.my-github-token>>} \
+              snyk-universal-broker \
+              .
+          working_directory: snyk-universal-broker
+      - run:
+          name: Test Import (Deployment)
           command: |
             LOG_LEVEL="debug" \
               SNYK_TOKEN=${<<parameters.snyk-token>>} \

--- a/README.md
+++ b/README.md
@@ -570,3 +570,9 @@ helm install ... --set credentialReferences.MY_GITHUB_TOKEN=<gh-pat>
 | `extraEnvVars`       | Optionally specify extra list of additional environment variables for Broker container                    | `[]`  |
 | `extraEnvVarsCM`     | Optionally specify one or more external configmaps containing additional environment variables for Broker | `[]`  |
 | `extraEnvVarsSecret` | Optionally specify one or more external secrets containing additional environment variables for Broker    | `[]`  |
+
+### Workload
+
+| Name            | Description                                                    | Value           |
+| --------------- | -------------------------------------------------------------- | --------------- |
+| `workload.kind` | Workload kind to deploy. Can be "deployment" or "statefulset". | `"statefulset"` |

--- a/snyk-universal-broker/templates/deployment.yaml
+++ b/snyk-universal-broker/templates/deployment.yaml
@@ -1,6 +1,6 @@
-{{- if ne .Values.workload.kind "deployment" }}
+{{- if eq .Values.workload.kind "deployment" }}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -11,12 +11,11 @@ metadata:
 spec:
   {{ include "snyk-broker.validateImagePullPolicy" . }}
   replicas: {{ include "snyk-broker.replicas" . }}
-  serviceName: {{ include "common.names.fullname" . }}
-  updateStrategy:
+  strategy:
     type: "RollingUpdate"
     rollingUpdate:
       maxUnavailable: 1
-      partition: 0
+      maxSurge: 1
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}

--- a/snyk-universal-broker/tests/workload_kind_test.yaml
+++ b/snyk-universal-broker/tests/workload_kind_test.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Workload Kind
+templates:
+  - deployment.yaml
+  - statefulset.yaml
+values:
+  - ../values.yaml
+  - fixtures/default_values.yaml
+
+tests:
+  - it: renders Deployment and skips StatefulSet when workload.kind is deployment
+    set:
+      workload.kind: deployment
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: deployment.yaml
+      - isKind:
+          of: Deployment
+        template: deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: statefulset.yaml
+
+  - it: renders StatefulSet and skips Deployment when workload.kind is statefulset
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: statefulset.yaml
+      - isKind:
+          of: StatefulSet
+        template: statefulset.yaml
+      - hasDocuments:
+          count: 0
+        template: deployment.yaml
+
+  - it: renders StatefulSet and skips Deployment when workload.kind is unknown
+    set:
+      workload.kind: unknown
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: statefulset.yaml
+      - isKind:
+          of: StatefulSet
+        template: statefulset.yaml
+      - hasDocuments:
+          count: 0
+        template: deployment.yaml

--- a/snyk-universal-broker/values.yaml
+++ b/snyk-universal-broker/values.yaml
@@ -415,6 +415,11 @@ extraEnvVarsCM: []
 ## @param extraEnvVarsSecret Optionally specify one or more external secrets containing additional environment variables for Broker
 extraEnvVarsSecret: []
 
+## @section Workload
+## @param workload.kind [string, default: "statefulset"] Workload kind to deploy. Can be "deployment" or "statefulset".
+workload:
+  kind: "statefulset"
+
 ## @skip global.compatibility.openshift.adaptSecurityContext [default: auto] Set to false to disable security context adaptations for OpenShift. If left in "auto", will remove default user/group values that will violate an OpenShift Security Context
 global:
   compatibility:


### PR DESCRIPTION
This PR adds a possibility to render Deployment or StatefulSet for Broker workload.

New value 'workload.kind' (deployment or statefulset) is used to render Deployment or StatefulSet template. Fallback and default value is `statefulset`.