### PR TITLE
feat: align happy eyeball fix via broker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,18 +411,19 @@ helm install ... --set credentialReferences.MY_GITHUB_TOKEN=<gh-pat>
 
 ### Serving over HTTPS and Certificate Trust
 
-| Name                         | Description                                                                                    | Value                 |
-| ---------------------------- | ---------------------------------------------------------------------------------------------- | --------------------- |
-| `caCert`                     | Set caCert to read certificate content from the values.yaml file as a multiline string:        | `""`                  |
-| `caCertMount.path`           | the path to mount a certificate bundle to                                                      | `"/home/node/cacert"` |
-| `caCertMount.name`           | the filename to write a certificate bundle to                                                  | `"cacert"`            |
-| `caCertSecret.name`          | set to read a CA cert from an external secret                                                  | `""`                  |
-| `caCertSecret.caCertKey`     | set to read the ca cert from a different key                                                   | `ca.pem`              |
-| `disableAllCertificateTrust` | Set to `true` to disable trust of **all** certificates, including any provided CAs             | `false`               |
-| `localWebServer.https`       | enables Broker client to run a HTTPS server instead of the default HTTP server                 | `false`               |
-| `localWebServer.certificate` | Provide HTTPS cert                                                                             | `""`                  |
-| `localWebServer.key`         | Provides HTTPS cert key                                                                        | `""`                  |
-| `localWebServerSecret.name`  | the name of the secret to create or (if cert and key are empty) the existing TLS secret to use | `""`                  |
+| Name                            | Description                                                                                              | Value                 |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------- |
+| `caCert`                        | Set caCert to read certificate content from the values.yaml file as a multiline string:                  | `""`                  |
+| `caCertMount.path`              | the path to mount a certificate bundle to                                                                | `"/home/node/cacert"` |
+| `caCertMount.name`              | the filename to write a certificate bundle to                                                            | `"cacert"`            |
+| `caCertSecret.name`             | set to read a CA cert from an external secret                                                            | `""`                  |
+| `caCertSecret.caCertKey`        | set to read the ca cert from a different key                                                             | `ca.pem`              |
+| `disableAllCertificateTrust`    | Set to `true` to disable trust of **all** certificates, including any provided CAs                       | `false`               |
+| `ipv6ConnectivityCheck.enabled` | Set to `false` to disable IPv6 connectivity check in broker (sets IPV6_CONNECTIVITY_CHECK_ENABLED=false) | `true`                |
+| `localWebServer.https`          | enables Broker client to run a HTTPS server instead of the default HTTP server                           | `false`               |
+| `localWebServer.certificate`    | Provide HTTPS cert                                                                                       | `""`                  |
+| `localWebServer.key`            | Provides HTTPS cert key                                                                                  | `""`                  |
+| `localWebServerSecret.name`     | the name of the secret to create or (if cert and key are empty) the existing TLS secret to use           | `""`                  |
 
 ### Proxy Configuration
 

--- a/snyk-universal-broker/templates/deployment.yaml
+++ b/snyk-universal-broker/templates/deployment.yaml
@@ -180,6 +180,10 @@ spec:
             - name: INSECURE_DOWNSTREAM
               value: "true"
           {{- end }}
+          {{- if not .Values.ipv6ConnectivityCheck.enabled }}
+            - name: IPV6_CONNECTIVITY_CHECK_ENABLED
+              value: "false"
+          {{- end }}
         # Custom environment variables
         {{- range .Values.extraEnvVars }}
             - name: {{ .name }}

--- a/snyk-universal-broker/templates/statefulset.yaml
+++ b/snyk-universal-broker/templates/statefulset.yaml
@@ -181,6 +181,10 @@ spec:
             - name: INSECURE_DOWNSTREAM
               value: "true"
           {{- end }}
+          {{- if not .Values.ipv6ConnectivityCheck.enabled }}
+            - name: IPV6_CONNECTIVITY_CHECK_ENABLED
+              value: "false"
+          {{- end }}
         # Custom environment variables
         {{- range .Values.extraEnvVars }}
             - name: {{ .name }}

--- a/snyk-universal-broker/tests/ipv6_connectivity_test.yaml
+++ b/snyk-universal-broker/tests/ipv6_connectivity_test.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: IPv6 connectivity check tests
+templates:
+  - statefulset.yaml
+  - deployment.yaml
+values:
+  - ../values.yaml
+  - fixtures/default_values.yaml
+
+tests:
+  - it: does not set IPV6_CONNECTIVITY_CHECK_ENABLED by default on statefulset
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+        template: statefulset.yaml
+
+  - it: sets IPV6_CONNECTIVITY_CHECK_ENABLED=false on statefulset when ipv6ConnectivityCheck.enabled is false
+    set:
+      ipv6ConnectivityCheck.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+        template: statefulset.yaml
+
+  - it: does not set IPV6_CONNECTIVITY_CHECK_ENABLED on statefulset when ipv6ConnectivityCheck.enabled is true
+    set:
+      ipv6ConnectivityCheck.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+        template: statefulset.yaml
+
+  - it: does not set IPV6_CONNECTIVITY_CHECK_ENABLED by default on deployment
+    set:
+      workload.kind: deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+        template: deployment.yaml
+
+  - it: sets IPV6_CONNECTIVITY_CHECK_ENABLED=false on deployment when ipv6ConnectivityCheck.enabled is false
+    set:
+      workload.kind: deployment
+      ipv6ConnectivityCheck.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+        template: deployment.yaml
+
+  - it: does not set IPV6_CONNECTIVITY_CHECK_ENABLED on deployment when ipv6ConnectivityCheck.enabled is true
+    set:
+      workload.kind: deployment
+      ipv6ConnectivityCheck.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+        template: deployment.yaml

--- a/snyk-universal-broker/values.schema.json
+++ b/snyk-universal-broker/values.schema.json
@@ -434,6 +434,15 @@
       "type": "boolean",
       "default": false
     },
+    "ipv6ConnectivityCheck": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
     "httpProxy": {
       "$ref": "#/$defs/urlWithSchema"
     },

--- a/snyk-universal-broker/values.yaml
+++ b/snyk-universal-broker/values.yaml
@@ -125,6 +125,10 @@ caCertSecret:
 ## @param disableAllCertificateTrust [default: false] Set to `true` to disable trust of **all** certificates, including any provided CAs
 disableAllCertificateTrust: false
 
+## @param ipv6ConnectivityCheck.enabled [default: true] Set to `false` to disable IPv6 connectivity check in broker (sets IPV6_CONNECTIVITY_CHECK_ENABLED=false)
+ipv6ConnectivityCheck:
+  enabled: true
+
 ## @param localWebServer.https [default: false] enables Broker client to run a HTTPS server instead of the default HTTP server
 ## @param localWebServer.certificate [string] Provide HTTPS cert
 ## @param localWebServer.key [string] Provides HTTPS cert key


### PR DESCRIPTION
This PR adds `ipv6ConnectivityCheck.enabled` to control broker's IPv6 connectivity check. See [corresponding PR](https://github.com/snyk/broker/pull/1110).